### PR TITLE
Estä sellaisen kaavakohteen lisääminen, joka ei ole kokonaan kaavan ulkorajan sisäpuolella

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -5,7 +5,12 @@ import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Generator, Iterable, cast
 
-from qgis.core import QgsExpressionContextUtils, QgsProject, QgsVectorLayer, QgsWkbTypes
+from qgis.core import (
+    QgsExpressionContextUtils,
+    QgsProject,
+    QgsVectorLayer,
+    QgsWkbTypes,
+)
 from qgis.gui import QgsMapToolDigitizeFeature
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtWidgets import QDialog
@@ -56,6 +61,7 @@ from arho_feature_template.utils.db_utils import get_existing_database_connectio
 from arho_feature_template.utils.misc_utils import (
     LANGUAGE,
     check_layer_changes,
+    check_plan_feature_inside_plan,
     disconnect_signal,
     get_active_plan_id,
     handle_unsaved_changes,
@@ -387,6 +393,14 @@ class PlanManager(QObject):
             title = self.new_feature_dock.active_feature_type
 
         plan_feature.geom = feature.geometry()
+        plan_id = get_active_plan_id()
+        plan_layer = PlanLayer.get_from_project()
+
+        if not check_plan_feature_inside_plan(feature, plan_layer, plan_id):
+            msg = "Kaavakohde ei saa ylittää kaavan ulkorajaa"
+            iface.messageBar().pushWarning("", msg)
+            return
+
         attribute_form = PlanFeatureForm(
             plan_feature, title, self.regulation_group_libraries, self.active_plan_regulation_group_library
         )

--- a/arho_feature_template/gui/dialogs/import_features_form.py
+++ b/arho_feature_template/gui/dialogs/import_features_form.py
@@ -25,7 +25,12 @@ from arho_feature_template.project.layers.plan_layers import (
     plan_feature_layers,
     plan_layers,
 )
-from arho_feature_template.utils.misc_utils import iface, use_wait_cursor
+from arho_feature_template.utils.misc_utils import (
+    check_plan_feature_inside_plan,
+    get_active_plan_id,
+    iface,
+    use_wait_cursor,
+)
 
 if TYPE_CHECKING:
     from qgis.gui import QgsCheckableComboBox, QgsFieldComboBox, QgsMapLayerComboBox
@@ -231,6 +236,12 @@ class ImportFeaturesForm(QDialog, FormClass):  # type: ignore
         if not layer.isEditable():
             layer.startEditing()
         layer.beginEditCommand(edit_text)
+
+        plan_id = get_active_plan_id()
+        plan_layer = PlanLayer.get_from_project()
+
+        if not check_plan_feature_inside_plan(feature, plan_layer, plan_id):
+            return False
 
         if id_ is None:
             layer.addFeature(feature)


### PR DESCRIPTION
Asetin 1mm puskurin, joka mahdollistaa sellaisten kaavakohteiden lisäämisen, joilla on yksi tai useampi taitekohta kaavan ulkorajalla. Tämä ei välttämättä riitä sellaisissa tapauksissa, joissa tuomisen yhteydessä tehtävä reprojektointi aiheuttaa pieniä epätarkkuuksia. 