### PR TITLE
Korjaa virhe tyylien lisäämisessä

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -814,6 +814,8 @@ def _apply_style(layer: QgsVectorLayer) -> None:
     #     path = plugin_path("resources", "styles", "yleiskaava")
     # elif plan_type == PlanType.TOWN:
     #     path = plugin_path("resources", "styles", "asemakaava")
+    else:
+        return
 
     # Apply style to temp layer and copy symbology and labels from there to the actual layer
     geom_type = QgsWkbTypes.displayString(layer.wkbType())


### PR DESCRIPTION
Aiemmin, metodi `_apply_style` aiheutti virheen, jos luotu kaava oli muu kuin maakuntakaava, koska tiedostopolkua ei oltu määritelty.