### PR TITLE
Salli sama kirjaintunnus usealle kaavamääräysryhmälle saman kaavan sisällä

### DIFF
--- a/arho_feature_template/gui/dialogs/plan_feature_form.py
+++ b/arho_feature_template/gui/dialogs/plan_feature_form.py
@@ -159,52 +159,6 @@ class PlanFeatureForm(QDialog, FormClass):  # type: ignore
             self.plan_regulation_group_scrollarea_contents.layout().removeItem(self.scroll_area_spacer)
             self.scroll_area_spacer = None
 
-    def _check_regulation_group_letter_codes(self) -> bool:
-        seen_names = set()
-        existing_names = set()
-        duplicate_names = set()
-
-        def _is_existing_model_with_unmodified_letter_code(model: RegulationGroup, letter_code: str) -> bool:
-            return bool(model.id_ and letter_code == model.letter_code)
-
-        def _format_names(names, last_item_conjucation: str = "ja") -> str:
-            names = list(names)
-            formatted_names = ", ".join(f"'<b>{name}</b>'" for name in names[:-1])
-            formatted_names += f" {last_item_conjucation} " if len(names) > 1 else ""
-            formatted_names += f"'<b>{names[-1]}</b>'" if names else ""
-            return formatted_names
-
-        for reg_group_widget in self.regulation_group_widgets:
-            letter_code = reg_group_widget.letter_code.text()
-            if not letter_code:
-                continue
-
-            if (
-                not _is_existing_model_with_unmodified_letter_code(reg_group_widget.regulation_group, letter_code)
-                and letter_code in self.existing_group_letter_codes
-            ):
-                existing_names.add(letter_code)
-
-            if letter_code in seen_names:
-                duplicate_names.add(letter_code)
-
-            seen_names.add(letter_code)
-
-        if existing_names:
-            if len(existing_names) == 1:
-                msg = f"Kaavamääräysryhmä lyhyellä nimellä {_format_names(existing_names)} on jo olemassa."
-            else:
-                msg = f"Kaavamääräysryhmät lyhyillä nimillä {_format_names(existing_names)} ovat jo olemassa."
-            QMessageBox.critical(self, "Virhe", msg)
-            return False
-
-        if duplicate_names:
-            msg = f"Lomakkeella on useita kaavamääräysryhmiä, joilla on lyhyt nimi {_format_names(duplicate_names, 'tai')}."
-            QMessageBox.critical(self, "Virhe", msg)
-            return False
-
-        return True
-
     def _check_multiple_regulation_groups_with_principal_intended_use_regulations(self) -> bool:
         principal_intended_use_groups = {
             regulation_group_widget
@@ -309,8 +263,7 @@ class PlanFeatureForm(QDialog, FormClass):  # type: ignore
 
     def _on_ok_clicked(self):
         if (
-            self._check_regulation_group_letter_codes()
-            and self._check_multiple_regulation_groups_with_principal_intended_use_regulations()
+            self._check_multiple_regulation_groups_with_principal_intended_use_regulations()
             and self._check_feature_name()
         ):
             self.model = self.into_model()

--- a/arho_feature_template/gui/dialogs/plan_regulation_group_form.py
+++ b/arho_feature_template/gui/dialogs/plan_regulation_group_form.py
@@ -12,7 +12,6 @@ from qgis.PyQt.QtWidgets import (
     QDialogButtonBox,
     QHBoxLayout,
     QLabel,
-    QMessageBox,
     QScrollArea,
     QSizePolicy,
     QSplitter,
@@ -173,23 +172,6 @@ class PlanRegulationGroupForm(QDialog, FormClass):  # type: ignore
             )
             regulation_type_widgets[id_] = tree_widget_item
 
-    def _check_letter_code(self) -> bool:
-        letter_code = self.letter_code.text()
-
-        def _is_existing_model_with_unmodified_letter_code(model: RegulationGroup, letter_code: str) -> bool:
-            return bool(model.id_ and letter_code == model.letter_code)
-
-        if not letter_code:
-            return True
-        if (
-            not _is_existing_model_with_unmodified_letter_code(self.regulation_group, letter_code)
-            and letter_code in self.existing_group_letter_codes
-        ):
-            msg = f"Kaavamääräysryhmä lyhyellä nimellä '<b>{letter_code}</b>' on jo olemassa."
-            QMessageBox.critical(self, "Virhe", msg)
-            return False
-        return True
-
     def update_selected_regulation(self, item: QTreeWidgetItem, column: int):
         _, regulation_type_attributes = item.data(column, Qt.UserRole)
         text = regulation_type_attributes["description"]
@@ -250,6 +232,5 @@ class PlanRegulationGroupForm(QDialog, FormClass):  # type: ignore
         return model
 
     def _on_ok_clicked(self):
-        if self._check_letter_code():
-            self.model = self.into_model()
-            self.accept()
+        self.model = self.into_model()
+        self.accept()


### PR DESCRIPTION
Poista tarkistukset, jotka estävät saman kirjaintunnuksen usealla kaavamääräysryhmllä. Vaatii myös tietokantamuutoksen: https://github.com/GispoCoding/arho-ryhti/pull/520