### PR TITLE
Kaavan tuonnin toteutus

### DIFF
--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -6,14 +6,7 @@ import os
 from pathlib import Path
 from typing import TYPE_CHECKING, Generator, Iterable, cast
 
-from qgis.core import (
-    QgsExpressionContextUtils,
-    QgsFeature,
-    QgsGeometry,
-    QgsProject,
-    QgsVectorLayer,
-    QgsWkbTypes,
-)
+from qgis.core import QgsExpressionContextUtils, QgsFeature, QgsGeometry, QgsProject, QgsVectorLayer, QgsWkbTypes
 from qgis.gui import QgsMapToolDigitizeFeature
 from qgis.PyQt.QtCore import QObject, pyqtSignal
 from qgis.PyQt.QtWidgets import QDialog
@@ -33,6 +26,7 @@ from arho_feature_template.core.models import (
 from arho_feature_template.core.template_manager import TemplateManager
 from arho_feature_template.exceptions import UnsavedChangesError
 from arho_feature_template.gui.dialogs.import_features_form import ImportFeaturesForm
+from arho_feature_template.gui.dialogs.import_plan_form import ImportPlanForm
 from arho_feature_template.gui.dialogs.lifecycle_editor import LifecycleEditor
 from arho_feature_template.gui.dialogs.load_plan_dialog import LoadPlanDialog
 from arho_feature_template.gui.dialogs.manage_libraries import ManageLibrariesForm
@@ -251,6 +245,11 @@ class PlanManager(QObject):
             for file_path in get_user_plan_feature_library_config_files()
         ]
         self.new_feature_dock.initialize_plan_feature_libraries(self.plan_feature_libraries)
+
+    def open_import_plan_dialog(self):
+        dialog = ImportPlanForm(iface.mainWindow())
+        if dialog.exec_() and dialog.imported_plan_id:
+            self.set_active_plan(dialog.imported_plan_id)
 
     def open_import_features_dialog(self):
         import_features_form = ImportFeaturesForm(self.active_plan_regulation_group_library)
@@ -529,9 +528,7 @@ class PlanManager(QObject):
             )
             title = plan_feature.name
         else:
-            plan_feature = PlanFeature(
-                layer_name=self.new_feature_dock.active_feature_layer,
-            )
+            plan_feature = PlanFeature(layer_name=self.new_feature_dock.active_feature_layer)
             title = self.new_feature_dock.active_feature_type
 
         plan_feature.geom = feature.geometry()
@@ -891,9 +888,7 @@ def save_plan(plan: Plan) -> str | None:
         # Check for deleted legal effects
         for association in LegalEffectAssociationLayer.get_dangling_associations(plan_id, plan.legal_effect_ids):
             if not _delete_feature(
-                association,
-                LegalEffectAssociationLayer.get_from_project(),
-                "Oikeusvaikutuksen assosiaation poisto",
+                association, LegalEffectAssociationLayer.get_from_project(), "Oikeusvaikutuksen assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Oikeusvaikutuksen assosiaation poistaminen epäonnistui.")
 
@@ -1092,9 +1087,7 @@ def save_regulation(regulation: Regulation) -> str | None:
         # Check for plan theme to be deleted
         for association in PlanThemeAssociationLayer.get_dangling_regulation_associations(reg_id, regulation.theme_ids):
             if not _delete_feature(
-                association,
-                PlanThemeAssociationLayer.get_from_project(),
-                "Kaavoitusteeman assosiaation poisto",
+                association, PlanThemeAssociationLayer.get_from_project(), "Kaavoitusteeman assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Kaavoitusteeman assosiaation poistaminen epäonnistui.")
 
@@ -1225,9 +1218,7 @@ def save_proposition(proposition: Proposition) -> str | None:
             prop_id, proposition.theme_ids
         ):
             if not _delete_feature(
-                association,
-                PlanThemeAssociationLayer.get_from_project(),
-                "Kaavoitusteeman assosiaation poisto",
+                association, PlanThemeAssociationLayer.get_from_project(), "Kaavoitusteeman assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Kaavoitusteeman assosiaation poistaminen epäonnistui.")
 

--- a/arho_feature_template/gui/dialogs/import_plan_form.py
+++ b/arho_feature_template/gui/dialogs/import_plan_form.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from importlib import resources
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from qgis.PyQt import uic
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QLineEdit, QWidget
+
+from arho_feature_template.core.lambda_service import LambdaService
+from arho_feature_template.project.layers.code_layers import OrganisationLayer, PlanTypeLayer
+from arho_feature_template.utils.misc_utils import iface
+
+if TYPE_CHECKING:
+    from qgis.gui import QgsFileWidget
+
+    from arho_feature_template.gui.components.code_combobox import CodeComboBox, HierarchicalCodeComboBox
+
+ui_path = resources.files(__package__) / "import_plan_form.ui"
+FormClass, _ = uic.loadUiType(ui_path)
+
+
+class ImportPlanForm(QDialog, FormClass):  # type: ignore
+    file_selection: QgsFileWidget
+    line_edit_name: QLineEdit
+    combo_box_plan_type: HierarchicalCodeComboBox
+    combo_box_organization: CodeComboBox
+    line_edit_permanent_plan_identifier: QLineEdit
+    line_edit_producers_plan_identifier: QLineEdit
+    button_box_accept: QDialogButtonBox
+    button_box_overwrite: QDialogButtonBox
+    widget_input: QWidget
+    widget_replace: QWidget
+    widget_progress: QWidget
+
+    def __init__(self, parent: QWidget | None = None):
+        super().__init__(parent)
+
+        self.setupUi(self)
+        self.setModal(True)
+        self.setFixedWidth(550)
+
+        self.widget_replace.hide()
+        self.widget_progress.hide()
+        self.adjustSize()
+
+        self.button_box_accept.accepted.connect(self.import_plan)
+        self.button_box_accept.rejected.connect(self.reject)
+        self.button_box_overwrite.accepted.connect(lambda: self.import_plan(overwrite=True))
+        self.button_box_overwrite.rejected.connect(self.reject)
+
+        self.file_selection.fileChanged.connect(self.check_inputs)
+        self.line_edit_name.textChanged.connect(self.check_inputs)
+        self.combo_box_plan_type.currentIndexChanged.connect(self.check_inputs)
+        self.combo_box_organization.currentIndexChanged.connect(self.check_inputs)
+
+        self.button_box_accept.button(QDialogButtonBox.Ok).setEnabled(False)
+
+        self.combo_box_plan_type.populate_from_code_layer(PlanTypeLayer)
+        self.combo_box_organization.populate_from_code_layer(OrganisationLayer)
+
+        self.lambda_service = LambdaService()
+        self.lambda_service.plan_imported.connect(self.plan_imported)
+        self.lambda_service.plan_import_failed.connect(self.handle_import_failed)
+
+        self.imported_plan_id: str | None = None
+        self.plan_json: str | None = None
+        self.extra_data: dict | None = None
+
+    def check_inputs(self):
+        """Enables ok/save button only if both file paths are defined."""
+        if (
+            self.file_selection.filePath()
+            and self.line_edit_name.text()
+            and self.combo_box_plan_type.value()
+            and self.combo_box_organization.value()
+        ):
+            self.button_box_accept.button(QDialogButtonBox.Ok).setEnabled(True)
+        else:
+            self.button_box_accept.button(QDialogButtonBox.Ok).setEnabled(False)
+
+    def import_plan(self, overwrite: bool = False) -> None:  # noqa: FBT001, FBT002
+        self.widget_input.hide()
+        self.widget_replace.hide()
+        self.widget_progress.show()
+        self.adjustSize()
+
+        if not self.plan_json:
+            json_plan_path = Path(self.file_selection.filePath())
+            if not json_plan_path.exists():
+                return
+            self.plan_json = json_plan_path.read_text(encoding="utf-8")
+
+        if not self.extra_data:
+            self.extra_data = {
+                "name": self.line_edit_name.text(),
+                "plan_type_id": self.combo_box_plan_type.value(),
+                "organization_id": self.combo_box_organization.value(),
+                "permanent_plan_identifier": self.line_edit_permanent_plan_identifier.text() or None,
+                "producers_plan_identifier": self.line_edit_producers_plan_identifier.text() or None,
+            }
+
+        self.lambda_service.import_plan(self.plan_json, self.extra_data, overwrite)
+
+        return None
+
+    def plan_imported(self, plan_id: str):
+        self.imported_plan_id = plan_id
+        self.accept()
+
+    def handle_import_failed(self, error_message: str):
+        """If error message is "plan already exists", prompt user if they want to overwrite the plan."""
+        if "Plan already exists." in error_message:
+            self.widget_progress.hide()
+            self.widget_replace.show()
+            self.adjustSize()
+
+        else:
+            iface.messageBar().pushCritical("", f"Kaavan tuonti epäonnistui: {error_message}")
+            self.reject()

--- a/arho_feature_template/gui/dialogs/import_plan_form.ui
+++ b/arho_feature_template/gui/dialogs/import_plan_form.ui
@@ -1,0 +1,305 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>547</width>
+    <height>549</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Tuo kaava</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QWidget" name="widget_input" native="true">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_3">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <layout class="QFormLayout" name="formLayout_2">
+        <item row="0" column="0">
+         <widget class="QLabel" name="label">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;*&lt;/span&gt; Kaavan JSON:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QgsFileWidget" name="file_selection">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="filter">
+           <string>*.json</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="label_2">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;*&lt;/span&gt; Nimi:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QLineEdit" name="line_edit_name"/>
+        </item>
+        <item row="2" column="0">
+         <widget class="QLabel" name="label_3">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;*&lt;/span&gt; Kaavalaji:&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="2" column="1">
+         <widget class="HierarchicalCodeComboBox" name="combo_box_plan_type"/>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;span style=&quot; color:#ff0000;&quot;&gt;*&lt;/span&gt; Organisaatio&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="CodeComboBox" name="combo_box_organization"/>
+        </item>
+       </layout>
+      </item>
+      <item>
+       <widget class="QgsCollapsibleGroupBox" name="mGroupBox">
+        <property name="title">
+         <string>Tunnukset</string>
+        </property>
+        <property name="collapsed">
+         <bool>false</bool>
+        </property>
+        <layout class="QFormLayout" name="formLayout">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Pysyvä kaavatunnus:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_6">
+           <property name="text">
+            <string>Tuottajan kaavatunnus:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="line_edit_permanent_plan_identifier"/>
+         </item>
+         <item row="1" column="1">
+          <widget class="QLineEdit" name="line_edit_producers_plan_identifier"/>
+         </item>
+        </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QDialogButtonBox" name="button_box_accept">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+        </property>
+        <property name="centerButtons">
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_progress" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Kaavaa syötetään tietokantaan.</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QProgressBar" name="progressBar">
+        <property name="maximum">
+         <number>0</number>
+        </property>
+        <property name="value">
+         <number>-1</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_3">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widget_replace" native="true">
+     <layout class="QVBoxLayout" name="verticalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="verticalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="label_8">
+        <property name="text">
+         <string>Kaava on jo olemassa. Haluatko korvata sen?</string>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDialogButtonBox" name="button_box_overwrite">
+        <property name="standardButtons">
+         <set>QDialogButtonBox::No|QDialogButtonBox::Yes</set>
+        </property>
+        <property name="centerButtons">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFileWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfilewidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>CodeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>arho_feature_template.gui.components.code_combobox</header>
+  </customwidget>
+  <customwidget>
+   <class>HierarchicalCodeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>arho_feature_template.gui.components.code_combobox</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/arho_feature_template/plugin.py
+++ b/arho_feature_template/plugin.py
@@ -168,15 +168,23 @@ class Plugin:
             triggered_callback=self.plan_manager.digitize_plan_geometry,
             add_to_menu=False,
             add_to_toolbar=False,
-            status_tip="Luo uusi kaava piirtämällä",
+            status_tip="Luo uusi kaava piirtämällä kaavarajaus",
         )
-        self.import_plan_action = self.add_action(
+        self.new_plan_from_border = self.add_action(
             text="Tuo kaavan ulkoraja",
             icon=QIcon(resources_path("icons", "toolbar", "luo_kaava2.svg")),
             triggered_callback=self.plan_manager.import_plan_geometry,
             add_to_menu=False,
             add_to_toolbar=False,
-            status_tip="Luo uusi kaava tuomalla jo olemassa oleva kaavan ulkorajan geometria",
+            status_tip="Luo uusi kaava tuomalla kaavarajaus toiselta tasolta",
+        )
+        self.import_plan = self.add_action(
+            text="Tuo kaava",
+            icon=QgsApplication.getThemeIcon("mActionSharingImport.svg"),
+            triggered_callback=self.plan_manager.open_import_plan_dialog,
+            add_to_menu=False,
+            add_to_toolbar=False,
+            status_tip="Tuo kaavan JSON tietokantaan",
         )
 
         self.new_plan_button = QToolButton()
@@ -187,7 +195,8 @@ class Plugin:
 
         menu = QMenu()
         menu.addAction(self.draw_new_plan_action)
-        menu.addAction(self.import_plan_action)
+        menu.addAction(self.new_plan_from_border)
+        menu.addAction(self.import_plan)
         self.new_plan_button.setMenu(menu)
         self.new_plan_action = self.toolbar.addWidget(self.new_plan_button)
 
@@ -316,7 +325,7 @@ class Plugin:
             text="Tuo kaavakohteita",
             icon=QgsApplication.getThemeIcon("mActionSharingImport.svg"),
             triggered_callback=self.plan_manager.open_import_features_dialog,
-            add_to_menu=True,
+            add_to_menu=False,
             add_to_toolbar=True,
             status_tip="Tuo kaavakohteita tietokantaan toisilta vektoritasoilta",
         )
@@ -357,7 +366,7 @@ class Plugin:
             status_tip="Muokkaa pluginin asetuksia",
         )
 
-        self.project_depending_actions = [self.draw_new_plan_action, self.import_plan_action, self.load_plan_action]
+        self.project_depending_actions = [self.draw_new_plan_action, self.new_plan_from_border, self.load_plan_action]
         self.plan_depending_actions = [
             self.edit_plan_action,
             self.edit_lifecycles_action,


### PR DESCRIPTION
Mahdollistaa ryhti-muotoisen kaava json tiedoston importoimisen tietokantaan.
Vaatii toimiakseen backendin https://github.com/GispoCoding/arho-ryhti/pull/527
