### PR TITLE
Korjaus validoinnin virheenkäsittelyyn

### DIFF
--- a/arho_feature_template/core/lambda_service.py
+++ b/arho_feature_template/core/lambda_service.py
@@ -169,9 +169,16 @@ class LambdaService(QObject):
         validation_errors = response_body["ryhti_responses"]
         plan_id = get_active_plan_id()
 
-        VALIDATION_ERROR_STATUS = HTTPStatus.UNPROCESSABLE_ENTITY  # noqa: N806
         validation_errors_of_active_plan = validation_errors.get(plan_id)
-        if validation_errors_of_active_plan.get("status") not in {HTTPStatus.OK, VALIDATION_ERROR_STATUS}:
+        if not validation_errors_of_active_plan:
+            self.validation_failed.emit(f"Arhovirhe - Lambdavastaus ei odotetun muotoinen: {validation_errors}")
+            return
+
+        SERVER_ERROR_MIN_STATUS = 500  # noqa: N806
+        SERVER_ERROR_MAX_STATUS = 599  # noqa: N806
+        if (
+            status := validation_errors_of_active_plan.get("status")
+        ) and SERVER_ERROR_MIN_STATUS <= status <= SERVER_ERROR_MAX_STATUS:
             self.validation_failed.emit(f"Ryhtivirhe: {validation_errors_of_active_plan}")
             return
 


### PR DESCRIPTION
400 on validi validointivirhe (tulee kun json ei validi), joten sitä ei pidä ilmoittaa virheenä validoinnissa.

Me ei tiedetä kaikki statuskoodeja mitä validointi rajapinta voi palauttaa. Ainakin sieltä tulee 400 ja 422.
Tästä syystä parempi käsitellä virheinä vaan 500 luokan koodit.