### PR TITLE
Asetuksiin parannuksia

### DIFF
--- a/arho_feature_template/core/lambda_service.py
+++ b/arho_feature_template/core/lambda_service.py
@@ -11,7 +11,8 @@ from qgis.PyQt.QtNetwork import QNetworkAccessManager, QNetworkProxy, QNetworkRe
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import iface
 
-from arho_feature_template.utils.misc_utils import get_active_plan_id, get_settings
+from arho_feature_template.core.settings_manager import SettingsManager
+from arho_feature_template.utils.misc_utils import get_active_plan_id
 
 
 class LambdaService(QObject):
@@ -70,7 +71,9 @@ class LambdaService(QObject):
 
     def _send_request(self, action: str, plan_id: str | None = None, payload: dict | None = None):
         """Sends a request to the lambda function."""
-        proxy_host, proxy_port, self.lambda_url = get_settings()
+        proxy_host = SettingsManager.get_proxy_host()
+        proxy_port = SettingsManager.get_proxy_port()
+        self.lambda_url = SettingsManager.get_lambda_url()
 
         # Initialize or reset proxy each time a request is sent. Incase settings have changed.
         if proxy_host and proxy_port:

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import Any
 
 from qgis.core import QgsSettings
@@ -20,7 +22,7 @@ class SettingsManager:
     def _get(cls, key: str, default: Any) -> Any:
         if not cls.MIGRATIONS_RUN:
             cls._migrate_keys()
-        return QgsSettings().value(cls._full_key(key), default)
+        return QgsSettings().value(cls._full_key(key), default, type(default))
 
     # LAMBDA SETTINGS
     @classmethod
@@ -32,12 +34,13 @@ class SettingsManager:
         cls._set("proxy_host", value)
 
     @classmethod
-    def get_proxy_port(cls, default: int = 5443) -> int:
-        return cls._get("proxy_port", default)
+    def get_proxy_port(cls, default: int = 5443) -> int | None:
+        port = cls._get("proxy_port", default)
+        return port if port > 0 else None
 
     @classmethod
-    def set_proxy_port(cls, value: int):
-        cls._set("proxy_port", value)
+    def set_proxy_port(cls, value: int | None):
+        cls._set("proxy_port", 0 if value is None else value)
 
     @classmethod
     def get_lambda_url(cls, default: str = "https://t5w26iqnsf.execute-api.eu-central-1.amazonaws.com/v0/ryhti") -> str:

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -87,7 +87,10 @@ class SettingsManager:
 
         proxy_port = settings.value("proxy_port", None)
         if proxy_port is not None:
-            cls.set_proxy_port(int(proxy_port))
+            try:
+                cls.set_proxy_port(int(proxy_port))
+            except ValueError:
+                cls.set_proxy_port(0)
             settings.remove("proxy_port")
 
         lambda_url = settings.value("lambda_url", None)

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -22,6 +22,7 @@ class SettingsManager:
             cls._migrate_keys()
         return QgsSettings().value(cls._full_key(key), default)
 
+    # LAMBDA SETTINGS
     @classmethod
     def get_proxy_host(cls, default: str = "localhost") -> str:
         return cls._get("proxy_host", default)
@@ -45,6 +46,15 @@ class SettingsManager:
     @classmethod
     def set_lambda_url(cls, value: str):
         cls._set("lambda_url", value)
+
+    # SERVICE BUS SETTINGS
+    @classmethod
+    def get_service_bus_enabled(cls, default: bool = True) -> bool:  # noqa: FBT001, FBT002
+        return cls._get("service_bus_enabled", default)
+
+    @classmethod
+    def set_service_bus_enabled(cls, value: bool):  # noqa: FBT001
+        cls._set("service_bus_enabled", value)
 
     @classmethod
     def _migrate_keys(cls):

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -1,0 +1,69 @@
+from typing import Any
+
+from qgis.core import QgsSettings
+from qgis.PyQt.QtCore import QSettings
+
+
+class SettingsManager:
+    GROUP = "plugins/arho"
+    MIGRATIONS_RUN = False
+
+    @classmethod
+    def _full_key(cls, key: str) -> str:
+        return f"{cls.GROUP}/{key}"
+
+    @classmethod
+    def _set(cls, key: str, value: Any):
+        QgsSettings().setValue(cls._full_key(key), value)
+
+    @classmethod
+    def _get(cls, key: str, default: Any) -> Any:
+        if not cls.MIGRATIONS_RUN:
+            cls._migrate_keys()
+        return QgsSettings().value(cls._full_key(key), default)
+
+    @classmethod
+    def get_proxy_host(cls, default: str = "localhost") -> str:
+        return cls._get("proxy_host", default)
+
+    @classmethod
+    def set_proxy_host(cls, value: int):
+        cls._set("proxy_host", value)
+
+    @classmethod
+    def get_proxy_port(cls, default: int = 5443) -> int:
+        return cls._get("proxy_port", default)
+
+    @classmethod
+    def set_proxy_port(cls, value: str):
+        cls._set("proxy_port", value)
+
+    @classmethod
+    def get_lambda_url(cls, default: str = "https://t5w26iqnsf.execute-api.eu-central-1.amazonaws.com/v0/ryhti") -> str:
+        return cls._get("lambda_url", default)
+
+    @classmethod
+    def set_lambda_url(cls, value: str):
+        cls._set("lambda_url", value)
+
+    @classmethod
+    def _migrate_keys(cls):
+        # Old settings
+        settings = QSettings("ArhoFeatureTemplate")
+
+        proxy_host = settings.value("proxy_host", None)
+        if proxy_host is not None:
+            cls.set_proxy_host(proxy_host)
+            settings.remove("proxy_host")
+
+        proxy_port = settings.value("proxy_port", None)
+        if proxy_port is not None:
+            cls.set_proxy_port(proxy_port)
+            settings.remove("proxy_port")
+
+        lambda_url = settings.value("lambda_url", None)
+        if lambda_url is not None:
+            cls.set_lambda_url(lambda_url)
+            settings.remove("lambda_url")
+
+        cls.MIGRATIONS_RUN = True

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -35,7 +35,7 @@ class SettingsManager:
         return cls._get("proxy_port", default)
 
     @classmethod
-    def set_proxy_port(cls, value: str):
+    def set_proxy_port(cls, value: int):
         cls._set("proxy_port", value)
 
     @classmethod
@@ -58,7 +58,7 @@ class SettingsManager:
 
         proxy_port = settings.value("proxy_port", None)
         if proxy_port is not None:
-            cls.set_proxy_port(proxy_port)
+            cls.set_proxy_port(int(proxy_port))
             settings.remove("proxy_port")
 
         lambda_url = settings.value("lambda_url", None)

--- a/arho_feature_template/core/settings_manager.py
+++ b/arho_feature_template/core/settings_manager.py
@@ -68,12 +68,12 @@ class SettingsManager:
 
     # SERVICE BUS SETTINGS
     @classmethod
-    def get_service_bus_enabled(cls, default: bool = True) -> bool:  # noqa: FBT001, FBT002
-        return cls._get("service_bus_enabled", default)
+    def get_data_exchange_layer_enabled(cls, default: bool = True) -> bool:  # noqa: FBT001, FBT002
+        return cls._get("data_exchange_layer_enabled", default)
 
     @classmethod
-    def set_service_bus_enabled(cls, value: bool):  # noqa: FBT001
-        cls._set("service_bus_enabled", value)
+    def set_data_exchange_layer_enabled(cls, value: bool):  # noqa: FBT001
+        cls._set("data_exchange_layer_enabled", value)
 
     @classmethod
     def _migrate_keys(cls):

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -2,7 +2,7 @@ from importlib import resources
 from typing import TYPE_CHECKING
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QLineEdit
+from qgis.PyQt.QtWidgets import QCheckBox, QDialog, QDialogButtonBox, QLineEdit
 
 from arho_feature_template.core.settings_manager import SettingsManager
 
@@ -22,6 +22,7 @@ class PluginSettings(QDialog, FormClass):  # type: ignore
         self.host: QLineEdit
         self.port: QgsSpinBox
         self.lambda_address: QLineEdit
+        self.service_bus_enabled: QCheckBox
         self.button_box: QDialogButtonBox
 
         # INIT
@@ -35,10 +36,12 @@ class PluginSettings(QDialog, FormClass):  # type: ignore
         self.host.setText(SettingsManager.get_proxy_host())
         self.port.setValue(SettingsManager.get_proxy_port())
         self.lambda_address.setText(SettingsManager.get_lambda_url())
+        self.service_bus_enabled.setChecked(SettingsManager.get_service_bus_enabled())
 
     def save_settings(self):
         SettingsManager.set_proxy_host(self.host.text())
         SettingsManager.set_proxy_port(self.port.value())
         SettingsManager.set_lambda_url(self.lambda_address.text())
+        SettingsManager.set_service_bus_enabled(self.service_bus_enabled.isChecked())
 
         self.accept()

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -34,6 +34,8 @@ class ArhoOptionsPage(QgsOptionsPageWidget, FormClass):  # type: ignore
         SettingsManager.set_lambda_url(self.lambda_address.text())
         SettingsManager.set_service_bus_enabled(self.service_bus_enabled.isChecked())
 
+        SettingsManager.finish()
+
     def load_settings(self):
         self.host.setText(SettingsManager.get_proxy_host())
         self.port.setValue(SettingsManager.get_proxy_port() or 0)

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -23,7 +23,7 @@ class ArhoOptionsPage(QgsOptionsPageWidget, FormClass):  # type: ignore
         self.host: QLineEdit
         self.port: QgsSpinBox
         self.lambda_address: QLineEdit
-        self.service_bus_enabled: QCheckBox
+        self.data_exchange_layer_enabled: QCheckBox
 
         # INIT
         self.load_settings()
@@ -32,7 +32,7 @@ class ArhoOptionsPage(QgsOptionsPageWidget, FormClass):  # type: ignore
         SettingsManager.set_proxy_host(self.host.text())
         SettingsManager.set_proxy_port(self.port.value())
         SettingsManager.set_lambda_url(self.lambda_address.text())
-        SettingsManager.set_service_bus_enabled(self.service_bus_enabled.isChecked())
+        SettingsManager.set_data_exchange_layer_enabled(self.data_exchange_layer_enabled.isChecked())
 
         SettingsManager.finish()
 
@@ -40,7 +40,7 @@ class ArhoOptionsPage(QgsOptionsPageWidget, FormClass):  # type: ignore
         self.host.setText(SettingsManager.get_proxy_host())
         self.port.setValue(SettingsManager.get_proxy_port() or 0)
         self.lambda_address.setText(SettingsManager.get_lambda_url())
-        self.service_bus_enabled.setChecked(SettingsManager.get_service_bus_enabled())
+        self.data_exchange_layer_enabled.setChecked(SettingsManager.get_data_exchange_layer_enabled())
 
 
 class ArhoOptionsPageFactory(QgsOptionsWidgetFactory):

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -1,8 +1,9 @@
 from importlib import resources
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtCore import QSettings
 from qgis.PyQt.QtWidgets import QDialog
+
+from arho_feature_template.core.settings_manager import SettingsManager
 
 ui_path = resources.files(__package__) / "plugin_settings.ui"
 FormClass, _ = uic.loadUiType(ui_path)
@@ -11,30 +12,19 @@ FormClass, _ = uic.loadUiType(ui_path)
 class PluginSettings(QDialog, FormClass):  # type: ignore
     def __init__(self, parent=None):
         super().__init__(parent)
-
         self.setupUi(self)
 
         self.saveButton.clicked.connect(self.save_settings)
-
         self.load_settings()
 
     def load_settings(self):
-        """Load settings from QSettings with default values."""
-        settings = QSettings("ArhoFeatureTemplate")
-
-        proxy_host = settings.value("proxy_host", "localhost")
-        proxy_port = settings.value("proxy_port", "5443")
-        lambda_url = settings.value("lambda_url", "https://t5w26iqnsf.execute-api.eu-central-1.amazonaws.com/v0/ryhti")
-
-        self.hostInput.setText(proxy_host)
-        self.portInput.setText(proxy_port)
-        self.lambdaInput.setText(lambda_url)
+        self.hostInput.setText(SettingsManager.get_proxy_host())
+        self.portInput.setText(str(SettingsManager.get_proxy_port()))
+        self.lambdaInput.setText(SettingsManager.get_lambda_url())
 
     def save_settings(self):
-        """Save settings to QSettings."""
-        settings = QSettings("ArhoFeatureTemplate")
-        settings.setValue("proxy_host", self.hostInput.text())
-        settings.setValue("proxy_port", self.portInput.text())
-        settings.setValue("lambda_url", self.lambdaInput.text())
+        SettingsManager.set_proxy_host(self.hostInput.text())
+        SettingsManager.set_proxy_port(int(self.portInput.text()))
+        SettingsManager.set_lambda_url(self.lambdaInput.text())
 
         self.accept()

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -34,7 +34,7 @@ class PluginSettings(QDialog, FormClass):  # type: ignore
 
     def load_settings(self):
         self.host.setText(SettingsManager.get_proxy_host())
-        self.port.setValue(SettingsManager.get_proxy_port())
+        self.port.setValue(SettingsManager.get_proxy_port() or 0)
         self.lambda_address.setText(SettingsManager.get_lambda_url())
         self.service_bus_enabled.setChecked(SettingsManager.get_service_bus_enabled())
 

--- a/arho_feature_template/gui/dialogs/plugin_settings.py
+++ b/arho_feature_template/gui/dialogs/plugin_settings.py
@@ -1,9 +1,13 @@
 from importlib import resources
+from typing import TYPE_CHECKING
 
 from qgis.PyQt import uic
-from qgis.PyQt.QtWidgets import QDialog
+from qgis.PyQt.QtWidgets import QDialog, QDialogButtonBox, QLineEdit
 
 from arho_feature_template.core.settings_manager import SettingsManager
+
+if TYPE_CHECKING:
+    from qgis.gui import QgsSpinBox
 
 ui_path = resources.files(__package__) / "plugin_settings.ui"
 FormClass, _ = uic.loadUiType(ui_path)
@@ -14,17 +18,27 @@ class PluginSettings(QDialog, FormClass):  # type: ignore
         super().__init__(parent)
         self.setupUi(self)
 
-        self.saveButton.clicked.connect(self.save_settings)
+        # TYPES
+        self.host: QLineEdit
+        self.port: QgsSpinBox
+        self.lambda_address: QLineEdit
+        self.button_box: QDialogButtonBox
+
+        # INIT
         self.load_settings()
 
+        self.button_box.button(QDialogButtonBox.Ok)
+        self.button_box.accepted.connect(self.save_settings)
+        self.button_box.rejected.connect(self.reject)
+
     def load_settings(self):
-        self.hostInput.setText(SettingsManager.get_proxy_host())
-        self.portInput.setText(str(SettingsManager.get_proxy_port()))
-        self.lambdaInput.setText(SettingsManager.get_lambda_url())
+        self.host.setText(SettingsManager.get_proxy_host())
+        self.port.setValue(SettingsManager.get_proxy_port())
+        self.lambda_address.setText(SettingsManager.get_lambda_url())
 
     def save_settings(self):
-        SettingsManager.set_proxy_host(self.hostInput.text())
-        SettingsManager.set_proxy_port(int(self.portInput.text()))
-        SettingsManager.set_lambda_url(self.lambdaInput.text())
+        SettingsManager.set_proxy_host(self.host.text())
+        SettingsManager.set_proxy_port(self.port.value())
+        SettingsManager.set_lambda_url(self.lambda_address.text())
 
         self.accept()

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>696</width>
-    <height>181</height>
+    <height>248</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -22,6 +22,12 @@
      <layout class="QFormLayout" name="formLayout">
       <item row="0" column="0">
        <widget class="QLabel" name="host_label">
+        <property name="minimumSize">
+         <size>
+          <width>113</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Proxy isäntä:</string>
         </property>
@@ -32,6 +38,12 @@
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="port_label">
+        <property name="minimumSize">
+         <size>
+          <width>113</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Proxy portti:</string>
         </property>
@@ -39,6 +51,12 @@
       </item>
       <item row="2" column="0">
        <widget class="QLabel" name="lambda_address_label">
+        <property name="minimumSize">
+         <size>
+          <width>113</width>
+          <height>0</height>
+         </size>
+        </property>
         <property name="text">
          <string>Lambdan osoite:</string>
         </property>
@@ -51,6 +69,47 @@
        <widget class="QgsSpinBox" name="port">
         <property name="maximum">
          <number>99999</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="service_bus_box">
+     <property name="title">
+      <string>Palveluväylä</string>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <item>
+       <widget class="QLabel" name="service_bus_enabled_label">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="minimumSize">
+         <size>
+          <width>113</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="text">
+         <string>Palveluväylä:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="service_bus_enabled">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string/>
         </property>
        </widget>
       </item>

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>300</width>
-    <height>205</height>
+    <width>696</width>
+    <height>181</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,44 +15,64 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="labelHost">
-     <property name="text">
-      <string>Proxy isäntä:</string>
+    <widget class="QGroupBox" name="lambda_settings_box">
+     <property name="title">
+      <string>Lambdan asetukset</string>
      </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="host_label">
+        <property name="text">
+         <string>Proxy isäntä:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="host"/>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="port_label">
+        <property name="text">
+         <string>Proxy portti:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="lambda_address_label">
+        <property name="text">
+         <string>Lambdan osoite:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QLineEdit" name="lambda_address"/>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="port">
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item>
-    <widget class="QLineEdit" name="hostInput"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="labelPort">
-     <property name="text">
-      <string>Proxy portti:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="portInput"/>
-   </item>
-   <item>
-    <widget class="QLabel" name="labelLambda">
-     <property name="text">
-      <string>Lambdan osoite:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <widget class="QLineEdit" name="lambdaInput"/>
-   </item>
-   <item>
-    <widget class="QPushButton" name="saveButton">
-     <property name="text">
-      <string>Tallenna asetukset</string>
+    <widget class="QDialogButtonBox" name="button_box">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -67,6 +67,9 @@
       </item>
       <item row="1" column="1">
        <widget class="QgsSpinBox" name="port">
+        <property name="specialValueText">
+         <string> </string>
+        </property>
         <property name="maximum">
          <number>99999</number>
         </property>

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -79,13 +79,13 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="service_bus_box">
+    <widget class="QGroupBox" name="data_exchange_layer_box">
      <property name="title">
       <string>Palveluväylä</string>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
-       <widget class="QLabel" name="service_bus_enabled_label">
+       <widget class="QLabel" name="data_exchange_layer_enabled_label">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -104,7 +104,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QCheckBox" name="service_bus_enabled">
+       <widget class="QCheckBox" name="data_exchange_layer_enabled">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
           <horstretch>0</horstretch>

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -1,17 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>PluginSettings</class>
- <widget class="QDialog" name="PluginSettings">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
     <width>696</width>
-    <height>248</height>
+    <height>295</height>
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Asetukset</string>
+   <string>Form</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
@@ -49,6 +49,16 @@
         </property>
        </widget>
       </item>
+      <item row="1" column="1">
+       <widget class="QgsSpinBox" name="port">
+        <property name="specialValueText">
+         <string> </string>
+        </property>
+        <property name="maximum">
+         <number>99999</number>
+        </property>
+       </widget>
+      </item>
       <item row="2" column="0">
        <widget class="QLabel" name="lambda_address_label">
         <property name="minimumSize">
@@ -64,16 +74,6 @@
       </item>
       <item row="2" column="1">
        <widget class="QLineEdit" name="lambda_address"/>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsSpinBox" name="port">
-        <property name="specialValueText">
-         <string> </string>
-        </property>
-        <property name="maximum">
-         <number>99999</number>
-        </property>
-       </widget>
       </item>
      </layout>
     </widget>
@@ -120,11 +120,17 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
      </property>
-    </widget>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>675</width>
+       <height>69</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/arho_feature_template/gui/dialogs/plugin_settings.ui
+++ b/arho_feature_template/gui/dialogs/plugin_settings.ui
@@ -99,7 +99,7 @@
          </size>
         </property>
         <property name="text">
-         <string>Palveluväylä:</string>
+         <string>Palveluväylä käytössä:</string>
         </property>
        </widget>
       </item>

--- a/arho_feature_template/gui/docks/validation_dock.py
+++ b/arho_feature_template/gui/docks/validation_dock.py
@@ -9,6 +9,7 @@ from qgis.gui import QgsDockWidget
 from qgis.PyQt import uic
 
 from arho_feature_template.core.lambda_service import LambdaService
+from arho_feature_template.core.settings_manager import SettingsManager
 from arho_feature_template.utils.misc_utils import get_active_plan_id, iface
 
 if TYPE_CHECKING:
@@ -40,6 +41,9 @@ class ValidationDock(QgsDockWidget, DockClass):  # type: ignore
         self.validate_plan_matter_button.clicked.connect(self.validate_plan_matter)
 
         self.enable_validation()
+
+        if not SettingsManager.get_service_bus_enabled():
+            self.validate_plan_matter_button.hide()
 
     def handle_validation_call_errors(self, error: str):
         self.validation_label.setText("Kaavan validoinnissa tapahtui virhe.")

--- a/arho_feature_template/gui/docks/validation_dock.py
+++ b/arho_feature_template/gui/docks/validation_dock.py
@@ -42,7 +42,7 @@ class ValidationDock(QgsDockWidget, DockClass):  # type: ignore
 
         self.enable_validation()
 
-        if not SettingsManager.get_service_bus_enabled():
+        if not SettingsManager.get_data_exchange_layer_enabled():
             self.validate_plan_matter_button.hide()
 
     def handle_validation_call_errors(self, error: str):

--- a/arho_feature_template/plugin.py
+++ b/arho_feature_template/plugin.py
@@ -11,7 +11,7 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QToolButton, QWidget
 from arho_feature_template.core.geotiff_creator import GeoTiffCreator
 from arho_feature_template.core.plan_manager import PlanManager
 from arho_feature_template.gui.dialogs.plugin_about import PluginAbout
-from arho_feature_template.gui.dialogs.plugin_settings import PluginSettings
+from arho_feature_template.gui.dialogs.plugin_settings import ArhoOptionsPageFactory
 from arho_feature_template.gui.dialogs.post_plan import PostPlanDialog
 from arho_feature_template.gui.docks.validation_dock import ValidationDock
 from arho_feature_template.qgis_plugin_tools.tools.custom_logging import setup_logger, teardown_logger
@@ -358,9 +358,11 @@ class Plugin:
             status_tip="Tarkastele pluginin tietoja",
         )
 
+        self._arho_options_page_factory = ArhoOptionsPageFactory()
+        iface.registerOptionsWidgetFactory(self._arho_options_page_factory)
         self.plugin_settings_action = self.add_action(
             text="Asetukset",
-            triggered_callback=self.open_settings,
+            triggered_callback=lambda _: iface.showOptionsDialog(iface.mainWindow(), "ARHO"),
             add_to_menu=True,
             add_to_toolbar=False,
             status_tip="Muokkaa pluginin asetuksia",
@@ -427,11 +429,6 @@ class Plugin:
         """Open the plugin about dialog."""
         about = PluginAbout()
         about.exec()
-
-    def open_settings(self):
-        """Open the plugin settings dialog."""
-        settings = PluginSettings()
-        settings.exec_()
 
     def edit_lifecycles(self):
         """Edit lifecycles of currently active plan."""

--- a/arho_feature_template/plugin.py
+++ b/arho_feature_template/plugin.py
@@ -10,6 +10,7 @@ from qgis.PyQt.QtWidgets import QAction, QMenu, QToolButton, QWidget
 
 from arho_feature_template.core.geotiff_creator import GeoTiffCreator
 from arho_feature_template.core.plan_manager import PlanManager
+from arho_feature_template.core.settings_manager import SettingsManager
 from arho_feature_template.gui.dialogs.plugin_about import PluginAbout
 from arho_feature_template.gui.dialogs.plugin_settings import ArhoOptionsPageFactory
 from arho_feature_template.gui.dialogs.post_plan import PostPlanDialog
@@ -330,25 +331,26 @@ class Plugin:
             status_tip="Tuo kaavakohteita tietokantaan toisilta vektoritasoilta",
         )
 
-        self.post_plan_matter_action = self.add_action(
-            text="Vie kaava-asia",
-            icon=QgsApplication.getThemeIcon("mActionSharingExport.svg"),
-            triggered_callback=self.post_plan_matter,
-            add_to_menu=True,
-            add_to_toolbar=True,
-            status_tip="Vie kaava-asia Ryhtiin",
-        )
-        self.post_plan_matter_action.setEnabled(False)  # Disable button by default
+        if SettingsManager.get_service_bus_enabled():
+            self.post_plan_matter_action = self.add_action(
+                text="Vie kaava-asia",
+                icon=QgsApplication.getThemeIcon("mActionSharingExport.svg"),
+                triggered_callback=self.post_plan_matter,
+                add_to_menu=True,
+                add_to_toolbar=True,
+                status_tip="Vie kaava-asia Ryhtiin",
+            )
+            self.post_plan_matter_action.setEnabled(False)  # Disable button by default
 
-        self.get_permanent_identifier_action = self.add_action(
-            text="Hae pysyvä kaavatunnus",
-            # icon=QgsApplication.getThemeIcon(""),
-            triggered_callback=self.plan_manager.get_permanent_plan_identifier,
-            add_to_menu=True,
-            add_to_toolbar=True,
-            status_tip="Hae kaavalle pysyvä kaavatunnus",
-        )
-        self.get_permanent_identifier_action.setEnabled(False)  # Disable button by default
+            self.get_permanent_identifier_action = self.add_action(
+                text="Hae pysyvä kaavatunnus",
+                # icon=QgsApplication.getThemeIcon(""),
+                triggered_callback=self.plan_manager.get_permanent_plan_identifier,
+                add_to_menu=True,
+                add_to_toolbar=True,
+                status_tip="Hae kaavalle pysyvä kaavatunnus",
+            )
+            self.get_permanent_identifier_action.setEnabled(False)  # Disable button by default
 
         self.plugin_about = self.add_action(
             text="Tietoja",
@@ -379,9 +381,9 @@ class Plugin:
             self.serialize_plan_action,
             self.create_geotiff_action,
             self.import_features_action,
-            self.get_permanent_identifier_action,
-            self.post_plan_matter_action,
         ]
+        if SettingsManager.get_service_bus_enabled():
+            self.plan_depending_actions += [self.get_permanent_identifier_action, self.post_plan_matter_action]
 
         # Initially actions are disabled because no plan is selected
         self.on_active_plan_unset()
@@ -397,7 +399,8 @@ class Plugin:
         self.plan_manager.plan_unset.connect(self.on_active_plan_unset)
         self.plan_manager.project_loaded.connect(self.on_project_loaded)
         self.plan_manager.project_cleared.connect(self.on_project_cleared)
-        self.plan_manager.plan_identifier_set.connect(self.update_ryhti_buttons)
+        if SettingsManager.get_service_bus_enabled():
+            self.plan_manager.plan_identifier_set.connect(self.update_ryhti_buttons)
         self.plan_manager.plan_identifier_set.connect(self.validation_dock.on_permanent_identifier_set)
 
         # (Re)initialize whenever a project is opened

--- a/arho_feature_template/plugin.py
+++ b/arho_feature_template/plugin.py
@@ -331,7 +331,7 @@ class Plugin:
             status_tip="Tuo kaavakohteita tietokantaan toisilta vektoritasoilta",
         )
 
-        if SettingsManager.get_service_bus_enabled():
+        if SettingsManager.get_data_exchange_layer_enabled():
             self.post_plan_matter_action = self.add_action(
                 text="Vie kaava-asia",
                 icon=QgsApplication.getThemeIcon("mActionSharingExport.svg"),
@@ -382,7 +382,7 @@ class Plugin:
             self.create_geotiff_action,
             self.import_features_action,
         ]
-        if SettingsManager.get_service_bus_enabled():
+        if SettingsManager.get_data_exchange_layer_enabled():
             self.plan_depending_actions += [self.get_permanent_identifier_action, self.post_plan_matter_action]
 
         # Initially actions are disabled because no plan is selected
@@ -399,7 +399,7 @@ class Plugin:
         self.plan_manager.plan_unset.connect(self.on_active_plan_unset)
         self.plan_manager.project_loaded.connect(self.on_project_loaded)
         self.plan_manager.project_cleared.connect(self.on_project_cleared)
-        if SettingsManager.get_service_bus_enabled():
+        if SettingsManager.get_data_exchange_layer_enabled():
             self.plan_manager.plan_identifier_set.connect(self.update_ryhti_buttons)
         self.plan_manager.plan_identifier_set.connect(self.validation_dock.on_permanent_identifier_set)
 

--- a/arho_feature_template/utils/misc_utils.py
+++ b/arho_feature_template/utils/misc_utils.py
@@ -6,7 +6,7 @@ from functools import wraps
 from typing import TYPE_CHECKING, Any, cast
 
 from qgis.core import QgsExpressionContextUtils, QgsProject, QgsVectorLayer
-from qgis.PyQt.QtCore import NULL, QSettings, Qt, pyqtBoundSignal
+from qgis.PyQt.QtCore import NULL, Qt, pyqtBoundSignal
 from qgis.PyQt.QtWidgets import QMessageBox
 from qgis.utils import OverrideCursor, iface
 
@@ -97,15 +97,6 @@ def set_active_plan_id(plan_id: str | None):
 def get_active_plan_id():
     """Retrieve the active plan ID stored as a project variable."""
     return QgsExpressionContextUtils.projectScope(QgsProject.instance()).variable("active_plan_id")
-
-
-def get_settings():
-    """Retrieve stored settings, using defaults if not set."""
-    settings = QSettings("ArhoFeatureTemplate")
-    proxy_host = settings.value("proxy_host", "localhost")
-    proxy_port = settings.value("proxy_port", "5443")
-    lambda_url = settings.value("lambda_url", "https://t5w26iqnsf.execute-api.eu-central-1.amazonaws.com/v0/ryhti")
-    return proxy_host, proxy_port, lambda_url
 
 
 def disconnect_signal(signal: pyqtBoundSignal) -> None:


### PR DESCRIPTION
- Asetukset löytyvät nyt QGISin Valinnat-ikkunasta (ARHOn asetuksiin pääsee kuitenkin yhä käsiksi suoraan lisäosan valikon alta)
- Lisätty asetus palveluväylän käytöstä. Asetus vaikuttaa siihen näytetäänkö työkalupalkissa painikkeita "Hae pysyvä kaavatunnus" ja "Vie kaava-asia", sekä siihen näkyykö validointipaneelissa "Validoi kaava-asia" nappia. Asetuksen muuttamisen jälkeen QGIS on käynnistettävä uudelleen
- Asetukset tallentuvat nyt QGIS-profiiliin eikä "globaaleiksi". Asetuksien migraation pitäisi tapahtua ensimmäisellä käyttökerralla automaattisesti eikä käyttäjän tarvitse tehdä mitään ylimääräistä

<img width="947" height="698" alt="image" src="https://github.com/user-attachments/assets/05efb7f0-4fb0-4b07-bd7c-04700bacef7f" />
