### PR TITLE
Korjaa kaavakohteen muokkauslomake

### DIFF
--- a/arho_feature_template/core/models.py
+++ b/arho_feature_template/core/models.py
@@ -249,7 +249,7 @@ class AdditionalInformation(PlanBaseModel):
 class Regulation(PlanBaseModel):
     regulation_type_id: str
     value: AttributeValue | None = None
-    additional_information: list[AdditionalInformation] = field(default_factory=list)
+    additional_information: list[AdditionalInformation] = field(default_factory=list, compare=False)
     regulation_number: int | None = None
     files: list[str] = field(default_factory=list, compare=False)
     theme_ids: list[str] = field(default_factory=list, compare=False)

--- a/arho_feature_template/gui/components/additional_information_widget.py
+++ b/arho_feature_template/gui/components/additional_information_widget.py
@@ -49,7 +49,6 @@ class AdditionalInformationWidget(QWidget, FormClass):  # type: ignore
         self.additional_info.setText(text)
 
         self.value_widget_manager: ValueWidgetManager | None = None
-
         default_value = AdditionalInformationTypeLayer.get_default_value_by_id(
             additional_information.additional_information_type_id
         )
@@ -68,7 +67,9 @@ class AdditionalInformationWidget(QWidget, FormClass):  # type: ignore
             id_=self.additional_information.id_,
             plan_regulation_id=self.additional_information.plan_regulation_id,
             modified=self.additional_information.modified,
-            value=self.value_widget_manager.into_model() if self.value_widget_manager else None,
+            value=self.value_widget_manager.into_model()
+            if self.value_widget_manager
+            else self.additional_information.value,
         )
         if not model.modified and model != self.additional_information:
             model.modified = True


### PR DESCRIPTION
1. Kaavamääräyksen lisätiedoista puuttui `compare=False`, jonka vuoksi kaikki kaavamääräykset tulkittiin muokatuiksi `RegulationWidget.into_model`-metodissa mikä johti kaikkien kaavamääräysryhmien uudelleentallennukseen.

2. Kaavamääräysryhmät, joissa oli lisätiedollisia kaavamääräyksiä tallennettiin aina uudestaan, kun painettiin OK "Muokkaa kaavakohdetta" -lomakkeessa, koska jokaisen lisätiedon `value`-kentän arvo muuttui `None`:ksi `AdditionalInformationWidget.into_model`-metodissa (puuttuvat `default`-arvon vuoksi).