### PR TITLE
Korjaa bugi Kaavasuunnitelmat-ikkunan avaamisessa

### DIFF
--- a/arho_feature_template/project/layers/plan_layers.py
+++ b/arho_feature_template/project/layers/plan_layers.py
@@ -246,7 +246,7 @@ class PlanLayer(AbstractPlanLayer):
         # Legal effects
         legal_effects_by_plan_id: dict[str, list[str]] = defaultdict(list)
         for feat in LegalEffectAssociationLayer.get_features_by_attribute_value("plan_id", plan_ids):
-            legal_effects_by_plan_id[feat["plan_id"]].append(feat["legal_effect_id"])
+            legal_effects_by_plan_id[feat["plan_id"]].append(feat["legal_effects_of_master_plan_id"])
 
         # Docs
         documents_by_plan_id: dict[str, list[Document]] = defaultdict(list)


### PR DESCRIPTION
Yleiskaavan tapauksessa, jos kaavalla oli oikeusvaikutuksia ja yritettiin avata kaavasuunnitelmat-ikkuna, tuli virhe johtuen väärästä kentän nimestä, kun yritettiin lukea ID Yleiskaavan oikeusvaikutusten assosiaatiot -tasolta. 