### PR TITLE
Korjaa kaavamääräysryhmän luominen pistemuotoiselle kaavalle

### DIFF
--- a/arho_feature_template/project/layers/code_layers.py
+++ b/arho_feature_template/project/layers/code_layers.py
@@ -259,7 +259,7 @@ class PlanRegulationGroupTypeLayer(AbstractCodeLayer):
         "Aluevaraus": "landUseRegulations",
         "Osa-alue": "otherAreaRegulations",
         "Viivat": "lineRegulations",
-        "Pisteet": "otherPointRegulations",
+        "Pisteet": "pointRegulations",
     }
 
     @classmethod


### PR DESCRIPTION
Creating regulation group for point plan object failed because there is no otherPointRegulations code in database.