### PR TITLE
Mahdollista kaavakohteiden tallennus kaavakohdepohjakirjastoon.

### DIFF
--- a/arho_feature_template/core/models.py
+++ b/arho_feature_template/core/models.py
@@ -112,6 +112,12 @@ class PlanFeatureLibrary(Library):
             "plan_features": [plan_feature.into_template_dict() for plan_feature in self.plan_features],
         }
 
+    def into_hash_map(self) -> defaultdict[int, list]:
+        plan_object_hash_map: defaultdict[int, list] = defaultdict(list)
+        for plan_object in self.plan_features:
+            plan_object_hash_map[plan_object.data_hash()].append(plan_object)
+        return plan_object_hash_map
+
 
 @dataclass
 class RegulationGroupLibrary(Library):

--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -320,12 +320,10 @@ class PlanManager(QObject):
             # Rewrite all new and remaining library config files and reinitialize libraries
             for library in updated_regulation_group_libraries:
                 TemplateManager.write_regulation_group_template_file(
-                    library.into_template_dict(), Path(library.file_path), overwrite=True
+                    library.into_template_dict(), Path(library.file_path)
                 )
             for library in updated_plan_feature_libraries:
-                TemplateManager.write_plan_feature_template_file(
-                    library.into_template_dict(), Path(library.file_path), overwrite=True
-                )
+                TemplateManager.write_plan_feature_template_file(library.into_template_dict(), Path(library.file_path))
         set_user_regulation_group_library_config_files(
             library.file_path for library in updated_regulation_group_libraries
         )
@@ -587,6 +585,7 @@ class PlanManager(QObject):
             plan_feature,
             title if title else "",
             self.regulation_group_libraries,
+            self.plan_feature_libraries,
             self.active_plan_regulation_group_library,
         )
         if attribute_form.exec_() and save_plan_feature(attribute_form.model) is not None:
@@ -598,7 +597,11 @@ class PlanManager(QObject):
 
         title = plan_feature.name if plan_feature.name else layer_name
         attribute_form = PlanObjectForm(
-            plan_feature, title, self.regulation_group_libraries, self.active_plan_regulation_group_library
+            plan_feature,
+            title,
+            self.regulation_group_libraries,
+            self.plan_feature_libraries,
+            self.active_plan_regulation_group_library,
         )
         if attribute_form.exec_() and save_plan_feature(attribute_form.model) is not None:
             self.update_active_plan_regulation_group_library()

--- a/arho_feature_template/gui/dialogs/plan_feature_form.ui
+++ b/arho_feature_template/gui/dialogs/plan_feature_form.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string>Plan feature form</string>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout_4">
+  <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <widget class="QgsCollapsibleGroupBox" name="plan_feature_groupbox">
      <property name="sizePolicy">
@@ -76,11 +76,44 @@
     </widget>
    </item>
    <item>
-    <widget class="QDialogButtonBox" name="button_box">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="save_to_library_button">
+       <property name="text">
+        <string>Tallenna kaavakohdepohjakirjastoon</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="button_box">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+       </property>
+      </widget>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/arho_feature_template/project/layers/plan_layers.py
+++ b/arho_feature_template/project/layers/plan_layers.py
@@ -12,6 +12,7 @@ from qgis.core import QgsFeature, QgsVectorLayerUtils
 from arho_feature_template.core.models import (
     AdditionalInformation,
     AttributeValue,
+    AttributeValueDataType,
     Document,
     Plan,
     PlanMatter,
@@ -510,7 +511,7 @@ class RegulationGroupAssociationLayer(AbstractPlanLayer):
 
 def attribute_value_model_from_feature(feature: QgsFeature) -> AttributeValue:
     return AttributeValue(
-        value_data_type=feature["value_data_type"],
+        value_data_type=AttributeValueDataType(feature["value_data_type"]) if feature["value_data_type"] else None,
         numeric_value=feature["numeric_value"],
         numeric_range_min=feature["numeric_range_min"],
         numeric_range_max=feature["numeric_range_max"],


### PR DESCRIPTION
#482 

Kaavakohde voidaan lisätä kaavakohdepohjakirjastoon kahdella tavalla.
1. Kaavan muokkauslomakkeelta 
<img width="947" height="848" alt="image" src="https://github.com/user-attachments/assets/37f2bf61-7114-45ad-8a6f-574edc4e56d8" />

2. Kaavakohteet -paneelin taulukosta 
<img width="518" height="243" alt="image" src="https://github.com/user-attachments/assets/f65f6d84-e5c7-4f52-9006-757e7c92eb20" />
