### PR TITLE
Suorituskyvyn parantaminen tekemällä vain yksi commit per taso

### DIFF
--- a/arho_feature_template/core/feature_editing.py
+++ b/arho_feature_template/core/feature_editing.py
@@ -2,10 +2,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, cast
 
-from qgis.core import QgsFeature
-from qgis.PyQt.QtCore import QObject, pyqtSignal
+from qgis.core import QgsProject
 
-from arho_feature_template.core.models import PlanObject
 from arho_feature_template.project.layers.plan_layers import (
     AdditionalInformationLayer,
     DocumentLayer,
@@ -28,57 +26,45 @@ from arho_feature_template.utils.misc_utils import (
 )
 
 if TYPE_CHECKING:
-    from qgis.core import QgsVectorLayer
+    from qgis.core import QgsFeature, QgsVectorLayer
 
     from arho_feature_template.core.models import (
         AdditionalInformation,
         Document,
         Plan,
         PlanMatter,
+        PlanObject,
         Proposition,
         Regulation,
         RegulationGroup,
     )
 
-
-class PlanObjectSaveNotifier(QObject):
-    plan_object_added = pyqtSignal(PlanObject, QgsFeature)
-    plan_object_edited = pyqtSignal(PlanObject)
+created_object_models: dict[str, PlanObject] = {}
 
 
-PLAN_OBJECT_NOTIFIER = PlanObjectSaveNotifier()
-
-
-def save_feature(
-    feature: QgsFeature, layer: QgsVectorLayer, id_: str | None, edit_text: str = ""
-) -> tuple[bool, QgsFeature]:
-    if not layer.isEditable():
-        layer.startEditing()
+def add_to_edit_buffer(feature: QgsFeature, layer: QgsVectorLayer, id_: str | None, edit_text: str = "") -> bool:
     layer.beginEditCommand(edit_text)
 
-    if id_ is None:
-        provider = layer.dataProvider()
-        result, out_feats = provider.addFeatures([feature])
-        if not result:
-            return False, feature
-        feature = out_feats[0]
-    else:
-        layer.updateFeature(feature)
+    result = layer.addFeature(feature) if id_ is None else layer.updateFeature(feature)
 
     layer.endEditCommand()
-    result = layer.commitChanges(stopEditing=False)
-    return result, feature
+    return result
+
+
+def delete_in_edit_buffer(feature: QgsFeature, layer: QgsVectorLayer, delete_text: str = "") -> bool:
+    layer.beginEditCommand(delete_text)
+
+    result = layer.deleteFeature(feature.id())
+
+    layer.endEditCommand()
+    return result
 
 
 def delete_feature(feature: QgsFeature, layer: QgsVectorLayer, delete_text: str = "") -> bool:
-    if not layer.isEditable():
-        layer.startEditing()
-    layer.beginEditCommand(delete_text)
+    delete_in_edit_buffer(feature, layer, delete_text)
+    result, _ = QgsProject.instance().commitChanges(stopEditing=False)
 
-    layer.deleteFeature(feature.id())
-
-    layer.endEditCommand()
-    return layer.commitChanges(stopEditing=False)
+    return result
 
 
 @use_wait_cursor
@@ -87,17 +73,24 @@ def save_plan_matter(plan_matter: PlanMatter) -> str | None:
     plan_matter_id = plan_matter.id_
     editing = plan_matter_id is not None
     if plan_matter.id_ is None or plan_matter.modified:
+        layer = PlanMatterLayer.get_from_project()
         feature = PlanMatterLayer.feature_from_model(plan_matter)
-        result, _ = save_feature(
+        if not layer.isEditable():
+            QgsProject.instance().startEditing(layer)
+
+        if not add_to_edit_buffer(
             feature=feature,
-            layer=PlanMatterLayer.get_from_project(),
+            layer=layer,
             id_=plan_matter_id,
             edit_text="Kaava-asian muokkaus" if editing else "Kaava-asian luominen",
-        )
-        if not result:
+        ):
             iface.messageBar().pushCritical("", "Kaava-asian tallentaminen epäonnistui")
             return None
         plan_matter_id = cast(str, feature["id"])
+
+        result, _ = QgsProject.instance().commitChanges(stopEditing=False)
+        if not result:
+            return None
 
     return plan_matter_id
 
@@ -110,14 +103,17 @@ def save_plan(plan: Plan) -> str | None:
         plan.plan_matter_id = get_active_plan_matter_id()
     editing = plan_id is not None
     if plan_id is None or plan.modified:
+        layer = PlanLayer.get_from_project()
         feature = PlanLayer.feature_from_model(plan)
-        result, _ = save_feature(
+        if not layer.isEditable():
+            QgsProject.instance().startEditing(layer)
+
+        if not add_to_edit_buffer(
             feature=feature,
-            layer=PlanLayer.get_from_project(),
+            layer=layer,
             id_=plan_id,
             edit_text="Kaavasuunnitelman muokkaus" if editing else "Kaavasuunnitelman luominen",
-        )
-        if not result:
+        ):
             iface.messageBar().pushCritical("", "Kaavasuunnitelman tallentaminen epäonnistui")
             return None
         plan_id = cast(str, feature["id"])
@@ -127,7 +123,7 @@ def save_plan(plan: Plan) -> str | None:
         for association in RegulationGroupAssociationLayer.get_dangling_associations(
             plan.general_regulations, plan_id, PlanLayer.name
         ):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association,
                 RegulationGroupAssociationLayer.get_from_project(),
                 "Kaavamääräysryhmän assosiaation poisto",
@@ -136,7 +132,7 @@ def save_plan(plan: Plan) -> str | None:
 
         # Check for deleted legal effects
         for association in LegalEffectAssociationLayer.get_dangling_associations(plan_id, plan.legal_effect_ids):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association, LegalEffectAssociationLayer.get_from_project(), "Oikeusvaikutuksen assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Oikeusvaikutuksen assosiaation poistaminen epäonnistui.")
@@ -144,25 +140,29 @@ def save_plan(plan: Plan) -> str | None:
         # Check for documents to be deleted
         doc_layer = DocumentLayer.get_from_project()
         for doc_feature in DocumentLayer.get_documents_to_delete(plan.documents, plan_id):
-            if not delete_feature(doc_feature, doc_layer, "Asiakirjan poisto"):
+            if not delete_in_edit_buffer(doc_feature, doc_layer, "Asiakirjan poisto"):
                 iface.messageBar().pushCritical("", "Asiakirjan poistaminen epäonnistui.")
 
     # Save general regulations
     if plan.general_regulations:
         for regulation_group in plan.general_regulations:
-            group_id = save_regulation_group(regulation_group, plan_id)
+            group_id = add_regulation_group_to_edit_buffer(regulation_group, plan_id)
             if group_id is None:
                 continue  # Skip association saving if saving regulation group failed
-            save_regulation_group_association(group_id, PlanLayer.name, plan_id)
+            add_regulation_group_association_to_edit_buffer(group_id, PlanLayer.name, plan_id)
 
     # Save legal effect associations
     for legal_effect_id in plan.legal_effect_ids:
-        save_legal_effect_association(plan_id, legal_effect_id)
+        add_legal_effect_association_to_edit_buffer(plan_id, legal_effect_id)
 
     # Save documents
     for document in plan.documents:
         document.plan_id = plan_id
-        save_document(document)
+        add_document_to_edit_buffer(document)
+
+    result, _ = QgsProject.instance().commitChanges(stopEditing=False)
+    if not result:
+        return None
 
     return plan_id
 
@@ -175,15 +175,18 @@ def save_plan_feature(plan_feature: PlanObject, plan_id: str | None = None) -> s
 
     feat_id = plan_feature.id_
     editing = feat_id is not None
+    feature = layer_class.feature_from_model(plan_feature, plan_id)
     if feat_id is None or plan_feature.modified:
-        feature = layer_class.feature_from_model(plan_feature, plan_id)
-        result, feat = save_feature(
+        layer = layer_class.get_from_project()
+        if not layer.isEditable():
+            QgsProject.instance().startEditing(layer)
+
+        if not add_to_edit_buffer(
             feature=feature,
-            layer=layer_class.get_from_project(),
+            layer=layer,
             id_=feat_id,
             edit_text="Kaavakohteen muokkaus" if editing else "Kaavakohteen lisäys",
-        )
-        if not result:
+        ):
             iface.messageBar().pushCritical("", "Kaavakohteen tallentaminen epäonnistui.")
             return None
         feat_id = cast(str, feature["id"])
@@ -195,7 +198,7 @@ def save_plan_feature(plan_feature: PlanObject, plan_id: str | None = None) -> s
         for association in RegulationGroupAssociationLayer.get_dangling_associations(
             plan_feature.regulation_groups, feat_id, layer_name
         ):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association,
                 RegulationGroupAssociationLayer.get_from_project(),
                 "Kaavamääräysryhmän assosiaation poisto",
@@ -204,31 +207,45 @@ def save_plan_feature(plan_feature: PlanObject, plan_id: str | None = None) -> s
 
     # Save regulation groups
     for group in plan_feature.regulation_groups:
-        group_id = save_regulation_group(group)
+        group_id = add_regulation_group_to_edit_buffer(group)
         if group_id is None:
             continue  # Skip association saving if saving regulation group failed
-        save_regulation_group_association(group_id, layer_name, feat_id)
+        add_regulation_group_association_to_edit_buffer(group_id, layer_name, feat_id)
 
-    if editing:
-        PLAN_OBJECT_NOTIFIER.plan_object_edited.emit(plan_feature)
-    else:
-        PLAN_OBJECT_NOTIFIER.plan_object_added.emit(plan_feature, feat)
+    created_object_models[feature["id"]] = plan_feature
+    result, _ = QgsProject.instance().commitChanges(stopEditing=False)
+    if not result:
+        return None
+
     return feat_id
 
 
 @use_wait_cursor
 def save_regulation_group(regulation_group: RegulationGroup, plan_id: str | None = None) -> str | None:
+    add_regulation_group_to_edit_buffer(regulation_group, plan_id)
+    result, _ = QgsProject.instance().commitChanges(stopEditing=False)
+    if not result:
+        return None
+
+    return plan_id
+
+
+@use_wait_cursor
+def add_regulation_group_to_edit_buffer(regulation_group: RegulationGroup, plan_id: str | None = None) -> str | None:
     group_id = regulation_group.id_
     editing = group_id is not None
     if group_id is None or regulation_group.modified:
+        layer = RegulationGroupLayer.get_from_project()
         feature = RegulationGroupLayer.feature_from_model(regulation_group, plan_id)
-        result, _ = save_feature(
+        if not layer.isEditable():
+            QgsProject.instance().startEditing(layer)
+
+        if not add_to_edit_buffer(
             feature=feature,
-            layer=RegulationGroupLayer.get_from_project(),
+            layer=layer,
             id_=group_id,
             edit_text="Kaavamääräysryhmän muokkaus" if editing else "Kaavamääräysryhmän lisäys",
-        )
-        if not result:
+        ):
             iface.messageBar().pushCritical("", "Kaavamääräysryhmän tallentaminen epäonnistui.")
             return None
         group_id = cast(str, feature["id"])
@@ -237,27 +254,26 @@ def save_regulation_group(regulation_group: RegulationGroup, plan_id: str | None
         # Check for regulations to be deleted
         regulation_layer = PlanRegulationLayer.get_from_project()
         for reg_feature in PlanRegulationLayer.get_regulations_to_delete(regulation_group.regulations, group_id):
-            if not delete_feature(reg_feature, regulation_layer, "Kaavamääräyksen poisto"):
+            if not delete_in_edit_buffer(reg_feature, regulation_layer, "Kaavamääräyksen poisto"):
                 iface.messageBar().pushCritical("", "Kaavamääräyksen poistaminen epäonnistui.")
 
         # Check for propositions to be deleted
         proposition_layer = PlanPropositionLayer.get_from_project()
         for prop_feature in PlanPropositionLayer.get_propositions_to_delete(regulation_group.propositions, group_id):
-            if not delete_feature(prop_feature, proposition_layer, "Kaavasuosituksen poisto"):
+            if not delete_in_edit_buffer(prop_feature, proposition_layer, "Kaavasuosituksen poisto"):
                 iface.messageBar().pushCritical("", "Kaavasuosituksen poistaminen epäonnistui.")
 
     # Save regulations
     if regulation_group.regulations:
         for regulation in regulation_group.regulations:
             regulation.regulation_group_id = group_id  # Updating regulation group ID
-            save_regulation(regulation)
+            add_regulation_to_edit_buffer(regulation)
 
     # Save propositions
     if regulation_group.propositions:
         for proposition in regulation_group.propositions:
             proposition.regulation_group_id = group_id  # Updating regulation group ID
-            save_proposition(proposition)
-
+            add_proposition_to_edit_buffer(proposition)
     return group_id
 
 
@@ -268,8 +284,10 @@ def delete_regulation_group(regulation_group: RegulationGroup, plan_id: str | No
 
     feature = RegulationGroupLayer.feature_from_model(regulation_group, plan_id)
     layer = RegulationGroupLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    if not delete_feature(feature, layer, "Kaavamääräysryhmän poisto"):
+    if not delete_in_edit_buffer(feature, layer, "Kaavamääräysryhmän poisto"):
         iface.messageBar().pushCritical("", "Kaavamääräysryhmän poistaminen epäonnistui.")
         return False
 
@@ -277,31 +295,43 @@ def delete_regulation_group(regulation_group: RegulationGroup, plan_id: str | No
 
 
 def save_regulation_group_association(regulation_group_id: str, layer_name: str, feature_id: str) -> bool:
+    add_regulation_group_association_to_edit_buffer(regulation_group_id, layer_name, feature_id)
+    result, _ = QgsProject.instance().commitChanges(stopEditing=False)
+    return result
+
+
+def add_regulation_group_association_to_edit_buffer(regulation_group_id: str, layer_name: str, feature_id: str) -> bool:
     if RegulationGroupAssociationLayer.association_exists(regulation_group_id, layer_name, feature_id):
         return True
     feature = RegulationGroupAssociationLayer.feature_from(regulation_group_id, layer_name, feature_id)
     layer = RegulationGroupAssociationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    result, _ = save_feature(feature=feature, layer=layer, id_=None, edit_text="Kaavamääräysryhmän assosiaation lisäys")
-    if not result:
+    if not add_to_edit_buffer(
+        feature=feature, layer=layer, id_=None, edit_text="Kaavamääräysryhmän assosiaation lisäys"
+    ):
         iface.messageBar().pushCritical("", "Kaavamääräysryhmän assosiaation tallentaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_regulation(regulation: Regulation) -> str | None:
+def add_regulation_to_edit_buffer(regulation: Regulation) -> str | None:
     reg_id = regulation.id_
     editing = reg_id is not None
     if reg_id is None or regulation.modified:
+        layer = PlanRegulationLayer.get_from_project()
         regulation_feature = PlanRegulationLayer.feature_from_model(regulation)
-        result, _ = save_feature(
+        if not layer.isEditable():
+            QgsProject.instance().startEditing(layer)
+
+        if not add_to_edit_buffer(
             feature=regulation_feature,
-            layer=PlanRegulationLayer.get_from_project(),
+            layer=layer,
             id_=reg_id,
             edit_text="Kaavamääräyksen muokkaus" if editing else "Kaavamääräyksen lisäys",
-        )
-        if not result:
+        ):
             iface.messageBar().pushCritical("", "Kaavamääräyksen tallentaminen epäonnistui.")
             return None
         reg_id = cast(str, regulation_feature["id"])
@@ -312,14 +342,14 @@ def save_regulation(regulation: Regulation) -> str | None:
         for info_feature in AdditionalInformationLayer.get_additional_information_to_delete(
             regulation.additional_information, reg_id
         ):
-            if not delete_feature(info_feature, info_layer, "Lisätiedon poisto"):
+            if not delete_in_edit_buffer(info_feature, info_layer, "Lisätiedon poisto"):
                 iface.messageBar().pushCritical("", "Liätiedon poistaminen epäonnistui.")
 
         # Check for verbal regulation types to be deleted
         for association in TypeOfVerbalRegulationAssociationLayer.get_dangling_associations(
             reg_id, regulation.verbal_regulation_type_ids
         ):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association,
                 TypeOfVerbalRegulationAssociationLayer.get_from_project(),
                 "Sanallisen kaavamääräyksen lajin assosiaation poisto",
@@ -330,25 +360,25 @@ def save_regulation(regulation: Regulation) -> str | None:
 
         # Check for plan theme to be deleted
         for association in PlanThemeAssociationLayer.get_dangling_regulation_associations(reg_id, regulation.theme_ids):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association, PlanThemeAssociationLayer.get_from_project(), "Kaavoitusteeman assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Kaavoitusteeman assosiaation poistaminen epäonnistui.")
 
     for additional_information in regulation.additional_information:
         additional_information.plan_regulation_id = reg_id
-        save_additional_information(additional_information)
+        add_additional_information_to_edit_buffer(additional_information)
 
     for verbal_regulation_type_id in regulation.verbal_regulation_type_ids:
-        save_type_of_verbal_regulation_association(reg_id, verbal_regulation_type_id)
+        add_type_of_verbal_regulation_association_to_edit_buffer(reg_id, verbal_regulation_type_id)
 
     for plan_theme_id in regulation.theme_ids:
-        save_plan_theme_association(plan_theme_id=plan_theme_id, regulation_id=reg_id)
+        add_plan_theme_association_to_edit_buffer(plan_theme_id=plan_theme_id, regulation_id=reg_id)
 
     return reg_id
 
 
-def save_plan_theme_association(
+def add_plan_theme_association_to_edit_buffer(
     plan_theme_id: str, regulation_id: str | None = None, proposition_id: str | None = None
 ) -> bool:
     if regulation_id is not None and PlanThemeAssociationLayer.regulation_association_exists(
@@ -364,57 +394,67 @@ def save_plan_theme_association(
         plan_theme_id=plan_theme_id, plan_regulation_id=regulation_id, plan_proposition_id=proposition_id
     )
     layer = PlanThemeAssociationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    result, _ = save_feature(feature=feature, layer=layer, id_=None, edit_text="Kaavoitusteeman assosiaation lisäys")
-    if not result:
+    if not add_to_edit_buffer(feature=feature, layer=layer, id_=None, edit_text="Kaavoitusteeman assosiaation lisäys"):
         iface.messageBar().pushCritical("", "Kaavoitusteeman assosiaation tallentaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_type_of_verbal_regulation_association(regulation_id: str, verbal_regulation_type_id: str) -> bool:
+def add_type_of_verbal_regulation_association_to_edit_buffer(
+    regulation_id: str, verbal_regulation_type_id: str
+) -> bool:
     if TypeOfVerbalRegulationAssociationLayer.association_exists(regulation_id, verbal_regulation_type_id):
         return True
     feature = TypeOfVerbalRegulationAssociationLayer.feature_from(regulation_id, verbal_regulation_type_id)
     layer = TypeOfVerbalRegulationAssociationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    result, _ = save_feature(
+    if not add_to_edit_buffer(
         feature=feature, layer=layer, id_=None, edit_text="Sanallisen kaavamääräyksen lajin assosiaation lisäys"
-    )
-    if not result:
+    ):
         iface.messageBar().pushCritical("", "Sanallisen kaavamääräyksen lajin assosiaation tallentaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_legal_effect_association(plan_id: str, legal_effect_id: str) -> bool:
+def add_legal_effect_association_to_edit_buffer(plan_id: str, legal_effect_id: str) -> bool:
     if LegalEffectAssociationLayer.association_exists(plan_id, legal_effect_id):
         return True
     feature = LegalEffectAssociationLayer.feature_from(plan_id, legal_effect_id)
     layer = LegalEffectAssociationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    result, _ = save_feature(feature=feature, layer=layer, id_=None, edit_text="Oikeusvaikutuksen assosiaation lisäys")
-    if not result:
+    if not add_to_edit_buffer(
+        feature=feature, layer=layer, id_=None, edit_text="Oikeusvaikutuksen assosiaation lisäys"
+    ):
         iface.messageBar().pushCritical("", "Oikeusvaikutuksen assosiaation tallentaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_additional_information(additional_information: AdditionalInformation) -> str | None:
+def add_additional_information_to_edit_buffer(additional_information: AdditionalInformation) -> str | None:
     if additional_information.id_ is not None and not additional_information.modified:
         return additional_information.id_
 
     feature = AdditionalInformationLayer.feature_from_model(additional_information)
-    result, _ = save_feature(
+    layer = AdditionalInformationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
+
+    if not add_to_edit_buffer(
         feature=feature,
-        layer=AdditionalInformationLayer.get_from_project(),
+        layer=layer,
         id_=additional_information.id_,
         edit_text="Lisätiedon lisäys" if additional_information.id_ is None else "Lisätiedon muokkaus",
-    )
-    if not result:
+    ):
         iface.messageBar().pushCritical("", "Lisätiedon tallentaminen epäonnistui.")
         return None
 
@@ -424,8 +464,10 @@ def save_additional_information(additional_information: AdditionalInformation) -
 def delete_additional_information(additional_information: AdditionalInformation) -> bool:
     feature = AdditionalInformationLayer.feature_from_model(additional_information)
     layer = AdditionalInformationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    if not delete_feature(feature, layer, "Lisätiedon poisto"):
+    if not delete_in_edit_buffer(feature, layer, "Lisätiedon poisto"):
         iface.messageBar().pushCritical("", "Lisätiedon poistaminen epäonnistui.")
         return False
 
@@ -435,28 +477,33 @@ def delete_additional_information(additional_information: AdditionalInformation)
 def delete_regulation(regulation: Regulation) -> bool:
     feature = PlanRegulationLayer.feature_from_model(regulation)
     layer = PlanRegulationLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    if not delete_feature(feature, layer, "Kaavamääräyksen poisto"):
+    if not delete_in_edit_buffer(feature, layer, "Kaavamääräyksen poisto"):
         iface.messageBar().pushCritical("", "Lisätiedon poistaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_proposition(proposition: Proposition) -> str | None:
+def add_proposition_to_edit_buffer(proposition: Proposition) -> str | None:
     prop_id = proposition.id_
     editing = prop_id is not None
     if proposition.id_ is not None and not proposition.modified:
         return proposition.id_
 
     feature = PlanPropositionLayer.feature_from_model(proposition)
-    result, _ = save_feature(
+    layer = PlanPropositionLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
+
+    if not add_to_edit_buffer(
         feature=feature,
-        layer=PlanPropositionLayer.get_from_project(),
+        layer=layer,
         id_=prop_id,
         edit_text="Kaavasuosituksen lisäys" if prop_id is None else "Kaavasuosituksen muokkaus",
-    )
-    if not result:
+    ):
         iface.messageBar().pushCritical("", "Kaavasuosituksen tallentaminen epäonnistui.")
         return None
     prop_id = cast(str, feature["id"])
@@ -466,13 +513,13 @@ def save_proposition(proposition: Proposition) -> str | None:
         for association in PlanThemeAssociationLayer.get_dangling_proposition_associations(
             prop_id, proposition.theme_ids
         ):
-            if not delete_feature(
+            if not delete_in_edit_buffer(
                 association, PlanThemeAssociationLayer.get_from_project(), "Kaavoitusteeman assosiaation poisto"
             ):
                 iface.messageBar().pushCritical("", "Kaavoitusteeman assosiaation poistaminen epäonnistui.")
 
     for plan_theme_id in proposition.theme_ids:
-        save_plan_theme_association(plan_theme_id=plan_theme_id, proposition_id=prop_id)
+        add_plan_theme_association_to_edit_buffer(plan_theme_id=plan_theme_id, proposition_id=prop_id)
 
     return feature["id"]
 
@@ -480,26 +527,31 @@ def save_proposition(proposition: Proposition) -> str | None:
 def delete_proposition(proposition: Proposition) -> bool:
     feature = PlanPropositionLayer.feature_from_model(proposition)
     layer = PlanPropositionLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
 
-    if not delete_feature(feature, layer, "Kaavasuosituksen poisto"):
+    if not delete_in_edit_buffer(feature, layer, "Kaavasuosituksen poisto"):
         iface.messageBar().pushCritical("", "Kaavasuosituksen poistaminen epäonnistui.")
         return False
 
     return True
 
 
-def save_document(document: Document) -> str | None:
+def add_document_to_edit_buffer(document: Document) -> str | None:
     if document.id_ is not None and not document.modified:
         return document.id_
 
     feature = DocumentLayer.feature_from_model(document)
-    result, _ = save_feature(
+    layer = DocumentLayer.get_from_project()
+    if not layer.isEditable():
+        QgsProject.instance().startEditing(layer)
+
+    if not add_to_edit_buffer(
         feature=feature,
-        layer=DocumentLayer.get_from_project(),
+        layer=layer,
         id_=document.id_,
         edit_text="Asiakirjan lisäys" if document.id_ is None else "Asiakirjan muokkaus",
-    )
-    if not result:
+    ):
         iface.messageBar().pushCritical("", "Asiakirjan tallentaminen epäonnistui.")
         return None
 

--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -373,6 +373,7 @@ class PlanManager(QObject):
             for feat_id in feat_ids:
                 for group in groups:
                     save_regulation_group_association(cast(str, group.id_), feat_layer_name, feat_id)
+        self.features_dock.create_plan_feature_view()
 
     def remove_selected_regulation_groups_from_features(
         self, groups: list[RegulationGroup], features: list[tuple[str, Generator[str]]]


### PR DESCRIPTION
Suorituskyky paranee merkittävästi, kun tehdään vain yksi commit per taso. Mutta jos tallentaa kaavakohteen, jolla useita kaavamääräysryhmiä, ryhmien otsikot katoavat. Tämä täytyy korjata. Lisäksi `save_feature` vaatii refaktorointia. Sitä on myös muokattu toisessa PR:ssä (#535).