### PR TITLE
Muokkaa koodiarvojen käyttöliittymää

### DIFF
--- a/arho_feature_template/core/models.py
+++ b/arho_feature_template/core/models.py
@@ -231,9 +231,9 @@ class AttributeValue(PlanBaseModel):
     text_value: LocalizedText | None = None
     text_syntax: str | None = None
 
-    code_list: str | None = None  # Name of code list / code layer
-    code_value: str | None = None  # ID that belongs to code_list
-    code_title: str | None = None  # Same as code_list
+    code_list: str | None = None  # URI of the code list
+    code_value: str | None = None  # Value of the code
+    code_title: str | None = None
 
     height_reference_point: str | None = None
 
@@ -265,7 +265,7 @@ class AttributeValue(PlanBaseModel):
             text_syntax=data.get("text_syntax"),
             code_list=data.get("code_list"),
             code_value=data.get("code_value"),
-            code_title=data.get("code_list"),  # Code title = code list
+            code_title=data.get("code_title"),
             height_reference_point=data.get("height_reference_point"),
         )
 
@@ -280,7 +280,7 @@ class AttributeValue(PlanBaseModel):
             "text_syntax": self.text_syntax,
             "code_list": self.code_list,
             "code_value": self.code_value,
-            "code_title": self.code_title,  # Code title = code list
+            "code_title": self.code_title,
             "height_reference_point": self.height_reference_point,
         }
 

--- a/arho_feature_template/core/plan_manager.py
+++ b/arho_feature_template/core/plan_manager.py
@@ -60,8 +60,8 @@ from arho_feature_template.gui.tools.inspect_plan_features_tool import InspectPl
 from arho_feature_template.project.layers.code_layers import (
     AdditionalInformationTypeLayer,
     LanguageLayer,
-    LifeCycleStatusLayer,
     LegalEffectsLayer,
+    LifeCycleStatusLayer,
     PlanRegulationGroupTypeLayer,
     PlanRegulationTypeLayer,
     PlanType,

--- a/arho_feature_template/gui/components/code_combobox.py
+++ b/arho_feature_template/gui/components/code_combobox.py
@@ -22,6 +22,8 @@ class CodeComboBox(QComboBox):
     def __init__(self, parent=None):
         super().__init__(parent)
 
+        self.code_layer: type[AbstractCodeLayer] | None = None
+
         self.addItem("NULL")
         self.setItemData(0, None)
 
@@ -35,6 +37,7 @@ class CodeComboBox(QComboBox):
             if isinstance(text, dict):
                 text = get_localized_text(text)
             self.addItem(text, id_)
+        self.code_layer = layer_type
 
     def value(self) -> str:
         return self.currentData()

--- a/arho_feature_template/project/layers/code_layers.py
+++ b/arho_feature_template/project/layers/code_layers.py
@@ -451,9 +451,9 @@ class LegalEffectsLayer(AbstractCodeLayer):
 code_layers = AbstractCodeLayer.__subclasses__()
 
 
-def get_code_layer(name: str) -> type[AbstractCodeLayer] | None:
+def get_code_layer_by_uri(uri: str) -> type[AbstractCodeLayer] | None:
     for code_layer in code_layers:
-        if code_layer.name == name:
+        if uri == code_layer.URI:
             return code_layer
 
     return None

--- a/arho_feature_template/resources/configs/additional_information.yaml
+++ b/arho_feature_template/resources/configs/additional_information.yaml
@@ -2,12 +2,12 @@ version: 1
 additional_information:
   - code: poisluettavaKayttotarkoitus
     data_type: Code
-    code_list: Kaavamääräyslaji
+    code_list: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
   - code: kerroksetJotaMaaraysKoskee
     data_type: NumericRange
   - code: kayttotarkoituskohdistus
     data_type: Code
-    code_list: Kaavamääräyslaji
+    code_list: http://uri.suomi.fi/codelist/rytj/RY_Kaavamaarayslaji
   - code: kayttotarkoituksenOsuusKerrosalastaK-m2
     data_type: PositiveNumeric
     unit: k-m2
@@ -25,6 +25,6 @@ additional_information:
     unit: "%"
   - code: rakennusluvanPeruste
     data_type: Code
-    code_list: Yleiskaavan oikeusvaikutus
+    code_list: http://uri.suomi.fi/codelist/rytj/oikeusvaik_YK
   - code: autopaikkojenSijoittuminenSallittu
     data_type: PositiveNumeric


### PR DESCRIPTION
Lisätiedot, jotka tarvitsevat ennaltamääritellyn koodiston arvon arvokseen (käyttötarkoituskohdistus, poisluettava käyttötarkoitus, rakennusluvan peruste) , näyttävät nyt vain yhden alasvetovalikon sallituilla koodiarvoilla.

<img width="1128" height="804" alt="image" src="https://github.com/user-attachments/assets/51ce8851-6c45-4a0c-a25e-0d116ed886c7" />
